### PR TITLE
small fix of missing whitespace

### DIFF
--- a/docs/1002_fix_01.md
+++ b/docs/1002_fix_01.md
@@ -15,7 +15,7 @@ Or you can use string concatenation:
 
 ```ts
 const str = "Here is some text" +
-  "that I want to break" +
+  "that I want to break " +
   "across multiple lines.";
 ```
 


### PR DESCRIPTION
String concatenation always bears the risk that some whitespace goes missing at the boundaries. This is a prime example here. The resulting text would read “... to breakacross multiple...”.